### PR TITLE
Update build configuration and ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 bin
 obj
 packages
-Directory.Build.targets
+Directory.Build.props
 Folder.DotSettings.user
 dist
 build

--- a/Directory.Build.props.example
+++ b/Directory.Build.props.example
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- Shared install directories -->
+    <DvInstallDir>D:\Programs\Derail Valley</DvInstallDir>
+    <UnityInstallDir>D:\Programs\Unity\2019.4.40f1\Editor</UnityInstallDir>
+  </PropertyGroup>
+</Project>

--- a/custom_item_components/Directory.Build.targets
+++ b/custom_item_components/Directory.Build.targets
@@ -1,6 +1,5 @@
 <Project>
 		<PropertyGroup>
-				<UnityInstallDir>D:\Programs\Unity\2019.4.40f1\Editor</UnityInstallDir>
 				<ReferencePath>
 						$(UnityInstallDir)\Data\Managed\
 				</ReferencePath>

--- a/custom_item_loader/Directory.Build.targets
+++ b/custom_item_loader/Directory.Build.targets
@@ -1,7 +1,5 @@
 <Project>
 		<PropertyGroup>
-				<DvInstallDir>D:\Programs\Derail Valley</DvInstallDir>
-				<UnityInstallDir>D:\Programs\Unity\2019.4.40f1\Editor</UnityInstallDir>
 				<ReferencePath>
 						$(DvInstallDir)\DerailValley_Data\Managed\;
 						$(DvInstallDir)\DerailValley_Data\Managed\UnityModManager\;


### PR DESCRIPTION
- Updated `.gitignore` to include `Directory.Build.props` and removed `Directory.Build.targets`
- Removed properties and targets from `Directory.Build.targets.example` related to Unity and Derail Valley.
- Added `Directory.Build.props.example` to define shared install directories.